### PR TITLE
sun50i-h618-orangepi-zero3: Change gpu node status to okay

### DIFF
--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
@@ -17,7 +17,7 @@ index edbfc83f390a..d8cb4deafde7 100644
  
 +&gpu {
 +	mali-supply = <&reg_dcdc1>;
-+	status = "disabled";
++	status = "okay";
 +};
 +
  &mmc0 {


### PR DESCRIPTION
# Description

The patch for enabling Mali GPU for Orange Pi Zero 3 was incorrect - the status was set to disabled.
Fix this by setting status to okay.

# How Has This Been Tested?

- [X] panfrost entries are mentioned in lsmod
- [X] 3D acceleration tested with Supertaxkart - no graphical artifacts or other abnormalities observed.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
